### PR TITLE
feat: no dead-end push/diff — confirm-miss preview, conflict diff, SI did-you-mean (v1.18.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mfa-servicenow-mcp"
-version = "1.18.1"
+version = "1.18.2"
 description = "A Model Context Protocol (MCP) server implementation for ServiceNow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/servicenow_mcp/policies/write_guards.py
+++ b/src/servicenow_mcp/policies/write_guards.py
@@ -168,6 +168,23 @@ _PUBLISH_CLASS_TOOLS: Dict[str, Optional[Dict[str, Any]]] = {
 }
 
 
+# tool_name → a read-only way to PREVIEW the pending change, so a confirm/publish
+# rejection is never a dead-end: it tells the caller exactly how to see what would
+# happen, then retry. Empty for tools with no obvious read-only preview.
+_PREVIEW_HINTS: Dict[str, str] = {
+    "update_remote_from_local": (
+        "Preview first with diff_local_component(path=...): it shows the exact line "
+        "diff, whether the remote drifted, and who last edited it — then retry."
+    ),
+}
+
+
+def preview_hint(tool_name: str) -> str:
+    """Read-only-preview guidance for *tool_name*, or '' if none. Appended to
+    confirm/publish rejections so they hand back the next actionable step."""
+    return _PREVIEW_HINTS.get(tool_name, "")
+
+
 # Read-only manage_X sub-actions (mirror of server.MANAGE_READ_ACTIONS).
 # Duplicated here to avoid circular import; keep in sync.
 _MANAGE_READ_ACTIONS: Dict[str, frozenset] = {
@@ -418,12 +435,13 @@ def _g7_publish_extra_confirm(ctx: WriteGuardContext) -> None:
     val = ctx.arguments.get(CONFIRM_PUBLISH_FIELD)
     if str(val).lower().strip() == CONFIRM_PUBLISH_VALUE:
         return
+    hint = preview_hint(ctx.tool_name)
     raise PolicyViolation(
         "G7",
         f"Publish-class action '{ctx.tool_name}' requires BOTH "
         f"confirm='approve' AND {CONFIRM_PUBLISH_FIELD}='{CONFIRM_PUBLISH_VALUE}'. "
         f"This prevents accidental publish/commit/push. "
-        f"Review what will be published before adding these flags.",
+        f"Review what will be published before adding these flags." + (f" {hint}" if hint else ""),
     )
 
 

--- a/src/servicenow_mcp/server.py
+++ b/src/servicenow_mcp/server.py
@@ -1280,10 +1280,13 @@ class ServiceNowMCP:
         if requires_confirmation:
             confirmation = str(arguments.get(CONFIRM_FIELD, "")).lower().strip()
             if confirmation != CONFIRM_VALUE:
+                from servicenow_mcp.policies.write_guards import preview_hint
+
+                hint = preview_hint(name)
                 raise ValueError(
                     f"This action for '{name}' will modify or delete data. "
                     f"To proceed, please add the parameter {CONFIRM_FIELD}='{CONFIRM_VALUE}' to your request "
-                    "to confirm you want to execute this."
+                    "to confirm you want to execute this." + (f" {hint}" if hint else "")
                 )
             logger.info("Executing confirmed action: tool=%s", name)
 

--- a/src/servicenow_mcp/tools/script_include_tools.py
+++ b/src/servicenow_mcp/tools/script_include_tools.py
@@ -156,10 +156,41 @@ def get_script_include(
         )
 
         if not records:
-            return {
+            result: Dict[str, Any] = {
                 "success": False,
                 "message": f"Script include not found: {params.script_include_id}",
             }
+            # No-dead-end: for a NAME miss (a sys_id miss has no near-match), offer
+            # fuzzy nameLIKE suggestions so the caller can retry in one step.
+            # fail_silently so a failed suggestion lookup never worsens the miss.
+            if not params.script_include_id.startswith("sys_id:"):
+                near, _ = sn_query_page(
+                    config,
+                    auth_manager,
+                    table="sys_script_include",
+                    query=f"nameLIKE{params.script_include_id}",
+                    fields="name,sys_id,api_name",
+                    limit=5,
+                    offset=0,
+                    display_value=False,
+                    fail_silently=True,
+                )
+                suggestions = [
+                    {
+                        "name": r.get("name"),
+                        "sys_id": r.get("sys_id"),
+                        "api_name": r.get("api_name"),
+                    }
+                    for r in near
+                    if r.get("name")
+                ]
+                if suggestions:
+                    result["did_you_mean"] = suggestions
+                    result["hint"] = (
+                        "No exact name match. Retry with one of did_you_mean[].name, "
+                        "or sys_id:<sys_id> for an exact id lookup."
+                    )
+            return result
 
         item = records[0]
 

--- a/src/servicenow_mcp/tools/sync_tools.py
+++ b/src/servicenow_mcp/tools/sync_tools.py
@@ -122,6 +122,9 @@ SUPPORTED_TABLES: Set[str] = {
 }
 
 MAX_DIFF_LINES = 120
+# Context lines for the line diff embedded in a CONFLICT response (P1-1) — kept
+# tight so a blocked push shows what changed without bloating the rejection.
+_CONFLICT_DIFF_CONTEXT = 3
 
 
 def _normalize_for_compare(text: str) -> str:
@@ -1137,41 +1140,7 @@ def diff_local_component(
             f"downloaded — review before pushing."
         )
 
-    diffs: List[Dict[str, Any]] = []
-    for field_name, file_path in resolved.fields.items():
-        if not file_path.exists():
-            continue
-        local_content = file_path.read_text(encoding="utf-8")
-        remote_content = str(remote_record.get(field_name) or "")
-
-        # Compare on a line-ending–normalized basis (same as the diff render) so a
-        # pure CRLF<->LF delta is not reported as a phantom "modified".
-        if _normalize_for_compare(local_content) == _normalize_for_compare(remote_content):
-            diffs.append({"field": field_name, "status": "unchanged"})
-            continue
-
-        diff_lines = list(
-            difflib.unified_diff(
-                remote_content.splitlines(),
-                local_content.splitlines(),
-                fromfile=f"remote/{field_name}",
-                tofile=f"local/{field_name}",
-                lineterm="",
-                n=params.context_lines,
-            )
-        )
-        if len(diff_lines) > MAX_DIFF_LINES:
-            diff_lines = diff_lines[:MAX_DIFF_LINES] + ["... [DIFF TRUNCATED FOR CONTEXT SAFETY]"]
-
-        diffs.append(
-            {
-                "field": field_name,
-                "status": "modified",
-                "diff": "\n".join(diff_lines),
-                "local_lines": len(local_content.splitlines()),
-                "remote_lines": len(remote_content.splitlines()),
-            }
-        )
+    diffs = _compute_field_diffs(resolved, remote_record, params.context_lines)
 
     result: Dict[str, Any] = {
         "mode": "diff",
@@ -1192,6 +1161,55 @@ def diff_local_component(
     if not resolved.instance_url:
         result["origin_unverified"] = _ORIGIN_UNVERIFIED_MSG
     return result
+
+
+def _compute_field_diffs(
+    resolved, remote_record: Dict[str, Any], context_lines: int
+) -> List[Dict[str, Any]]:
+    """Per-field unified line diff (remote -> local), line-ending normalized.
+
+    Read-only and network-free: callers pass an already-fetched remote_record.
+    A pure CRLF<->LF delta reads as 'unchanged'; oversized diffs are truncated to
+    MAX_DIFF_LINES for context safety. Shared by diff_local_component (review) and
+    the push CONFLICT response, so a blocked push shows WHAT would change without a
+    second round-trip — never a dead-end.
+    """
+    diffs: List[Dict[str, Any]] = []
+    for field_name, file_path in resolved.fields.items():
+        if not file_path.exists():
+            continue
+        local_content = file_path.read_text(encoding="utf-8")
+        remote_content = str(remote_record.get(field_name) or "")
+
+        # Compare on a line-ending–normalized basis (same as the diff render) so a
+        # pure CRLF<->LF delta is not reported as a phantom "modified".
+        if _normalize_for_compare(local_content) == _normalize_for_compare(remote_content):
+            diffs.append({"field": field_name, "status": "unchanged"})
+            continue
+
+        diff_lines = list(
+            difflib.unified_diff(
+                remote_content.splitlines(),
+                local_content.splitlines(),
+                fromfile=f"remote/{field_name}",
+                tofile=f"local/{field_name}",
+                lineterm="",
+                n=context_lines,
+            )
+        )
+        if len(diff_lines) > MAX_DIFF_LINES:
+            diff_lines = diff_lines[:MAX_DIFF_LINES] + ["... [DIFF TRUNCATED FOR CONTEXT SAFETY]"]
+
+        diffs.append(
+            {
+                "field": field_name,
+                "status": "modified",
+                "diff": "\n".join(diff_lines),
+                "local_lines": len(local_content.splitlines()),
+                "remote_lines": len(remote_content.splitlines()),
+            }
+        )
+    return diffs
 
 
 def _build_update_data_and_magnitude(resolved, remote_record):
@@ -1418,6 +1436,10 @@ def update_remote_from_local(
                 "local_downloaded_on": local_updated_on,
                 "record_hold": live_hold,
                 "component": component_info,
+                # P1-1: the line-level diff of what THIS push would overwrite, from
+                # the already-fetched remote_record (no extra round-trip). Lets the
+                # caller decide force=true vs re-download without re-diffing.
+                "diffs": _compute_field_diffs(resolved, remote_record, _CONFLICT_DIFF_CONTEXT),
             }
         if confirmed_other:
             logger.warning(

--- a/tests/test_script_include_tools.py
+++ b/tests/test_script_include_tools.py
@@ -283,6 +283,41 @@ class TestScriptIncludeTools(unittest.TestCase):
         self.assertIn("not found", result["message"])
 
     @patch("servicenow_mcp.tools.script_include_tools.sn_query_page")
+    def test_get_script_include_not_found_suggests_did_you_mean(self, mock_query_page):
+        """P2 no-dead-end: a NAME miss offers fuzzy nameLIKE suggestions."""
+        mock_query_page.side_effect = [
+            ([], 0),  # exact name= lookup: miss
+            (  # fuzzy nameLIKE lookup: near matches
+                [
+                    {"sys_id": "a1", "name": "MyUtils", "api_name": "global.MyUtils"},
+                    {"sys_id": "a2", "name": "MyUtilHelper", "api_name": "global.MyUtilHelper"},
+                ],
+                2,
+            ),
+        ]
+
+        params = GetScriptIncludeParams(script_include_id="MyUtil")
+        result = get_script_include(self.server_config, self.auth_manager, params)
+
+        self.assertFalse(result["success"])
+        self.assertIn("did_you_mean", result)
+        names = {s["name"] for s in result["did_you_mean"]}
+        self.assertIn("MyUtils", names)
+        self.assertIn("hint", result)
+
+    @patch("servicenow_mcp.tools.script_include_tools.sn_query_page")
+    def test_get_script_include_sys_id_miss_has_no_suggestions(self, mock_query_page):
+        """A sys_id miss has no near-match → no fuzzy lookup, no did_you_mean."""
+        mock_query_page.return_value = ([], 0)
+
+        params = GetScriptIncludeParams(script_include_id="sys_id:deadbeef")
+        result = get_script_include(self.server_config, self.auth_manager, params)
+
+        self.assertFalse(result["success"])
+        self.assertNotIn("did_you_mean", result)
+        self.assertEqual(mock_query_page.call_count, 1)  # only the exact lookup ran
+
+    @patch("servicenow_mcp.tools.script_include_tools.sn_query_page")
     def test_get_script_include_error(self, mock_query_page):
         """Test getting a script include with an error."""
         mock_query_page.side_effect = Exception("Test error")

--- a/tests/test_server_policy.py
+++ b/tests/test_server_policy.py
@@ -101,6 +101,36 @@ def test_call_tool_blocks_mutating_tool_without_confirmation(
     assert called["value"] is False
 
 
+def test_call_tool_push_confirm_miss_points_to_preview(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    # P0-2: a push confirm-miss must hand back the read-only preview step, never a
+    # bare dead-end. confirm_publish satisfies G7; the standard confirm is still
+    # missing, so the rejection must name diff_local_component — and not run.
+    server = _build_server(monkeypatch, tmp_path)
+
+    called = {"value": False}
+
+    def should_not_run(_config, _auth_manager, _params):
+        called["value"] = True
+        return {"ok": True}
+
+    server.tool_definitions["update_remote_from_local"] = (
+        should_not_run,
+        EmptyParams,
+        dict,
+        "blocked",
+        "raw_dict",
+    )
+    if "update_remote_from_local" not in server.enabled_tool_names:
+        server.enabled_tool_names.append("update_remote_from_local")
+
+    with pytest.raises(ValueError, match="diff_local_component"):
+        asyncio.run(
+            server._call_tool_impl("update_remote_from_local", {"confirm_publish": "approve"})
+        )
+
+    assert called["value"] is False
+
+
 def test_call_tool_allows_mutating_tool_with_confirmation(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ):

--- a/tests/test_sync_tools.py
+++ b/tests/test_sync_tools.py
@@ -777,6 +777,12 @@ class TestUpdateRemoteFromLocal:
         assert result["risk"]["other_user"] is True
         assert result["risk"]["level"] in ("high", "critical")
         assert "alice" in result["risk"]["message"]
+        # P1-1: the rejection carries the line-level diff of what would be
+        # overwritten, so the caller can decide without a second round-trip.
+        modified = [d for d in result["diffs"] if d.get("status") == "modified"]
+        assert modified, "CONFLICT must include the line diff of the pending push"
+        assert "script" in {d["field"] for d in modified}
+        assert "@@" in modified[0]["diff"] or "+" in modified[0]["diff"]
 
     @patch("servicenow_mcp.tools.sync_tools._write_sync_meta")
     @patch("servicenow_mcp.tools.sync_tools.update_portal_component")

--- a/tests/test_write_guards.py
+++ b/tests/test_write_guards.py
@@ -173,6 +173,28 @@ def test_g7_blocks_update_remote_from_local() -> None:
         run_write_guards(_SERVER, "update_remote_from_local", {})
 
 
+def test_g7_push_rejection_points_to_preview_no_dead_end() -> None:
+    # P0-2: the publish rejection must hand back the read-only preview step,
+    # never a dead-end the caller can't recover from.
+    with pytest.raises(PolicyViolation) as exc:
+        run_write_guards(_SERVER, "update_remote_from_local", {})
+    assert "diff_local_component" in str(exc.value)
+
+
+def test_g7_generic_publish_rejection_has_no_push_hint() -> None:
+    # The hint is push-specific; a generic publish-class rejection stays clean.
+    with pytest.raises(PolicyViolation) as exc:
+        run_write_guards(_SERVER, "publish_changeset", {"changeset_id": "abc"})
+    assert "diff_local_component" not in str(exc.value)
+
+
+def test_preview_hint_unknown_tool_is_empty() -> None:
+    from servicenow_mcp.policies.write_guards import preview_hint
+
+    assert preview_hint("manage_incident") == ""
+    assert "diff_local_component" in preview_hint("update_remote_from_local")
+
+
 def test_g7_blocks_manage_changeset_publish() -> None:
     with pytest.raises(PolicyViolation, match=r"\[G7\]"):
         run_write_guards(_SERVER, "manage_changeset", {"action": "publish"})


### PR DESCRIPTION
## Summary

Friction-reduction roadmap **P0-2 + P1-1 + P2** (issue #57). Guiding principle: *every rejection must hand back what's needed to finish in one more call — never a dead-end.*

**Safety:** the live push decision flow and the write-blocking gate are **unchanged**. All changes are additive or message-only, so the confirm/publish guarantees hold exactly as before (`confirm='approve'` + `confirm_publish='approve'` still both required to execute a push).

## P1-1 — CONFLICT response carries the line-level diff
- Extract the read-only diff loop into `_compute_field_diffs` (DRY — shared by `diff_local_component` and the push CONFLICT path).
- `update_remote_from_local`'s CONFLICT return now includes `diffs`, built from the **already-fetched** `remote_record` (no extra round-trip). The caller decides `force=true` vs re-download without re-diffing.

## P0-2 — confirm/publish rejection points to the preview
- New `_PREVIEW_HINTS` registry + `preview_hint()` in `write_guards`. The **G7 publish** rejection and the **standard confirm-miss** (`server.py`) append, for `update_remote_from_local`: *"Preview first with `diff_local_component(...)`"*.
- **No gate logic change** — only the rejection wording gained the actionable next step.
- Design note: a literal gate-exempted `dry_run` param was rejected because `update_remote_from_local` is triple-gated (G7 + confirm + post-confirm), so a carve-out would touch the write gate in 3 places. `diff_local_component` is already the read-only preview; pointing to it is strictly safer.

## P2 — script-include not-found offers fuzzy suggestions
- A NAME miss runs a **fail-silent** `nameLIKE` lookup and returns `did_you_mean[]` + a retry hint. A `sys_id:` miss skips it (no near-match). Never worsens a miss.

## Test plan
- [x] `pytest tests/` — **3327 passed, 5 skipped** (+6 new tests)
- [x] isort + black + ruff clean (pre-commit hooks passed)
- [x] New tests: conflict diff present; G7 + standard confirm-miss carry the preview hint; generic publish rejection stays clean; server-level confirm-miss integration; did-you-mean hit + sys_id-miss skip.

## Notes / remaining P2 (follow-up)
- Patch bump 1.18.1 → 1.18.2. Tag `v1.18.2` after merge.
- **Not in this PR (proposed next):** (a) expose `PORTAL_COMPONENT_EDITABLE_FIELDS` via `sn_schema`; (b) `widget_dependency` offline `_graph.json` fallback; (c) the **naming generalization** — `manage_portal_component` / `PORTAL_COMPONENT_EDITABLE_FIELDS` now cover non-portal code tables (Scripted REST, BR, etc.), so the `portal_` prefix is a misnomer. The rename touches a public tool name, so it deserves its own PR.