### PR TITLE
feat: P2 discoverability — sn_schema write-path + widget-dep offline hint (v1.18.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mfa-servicenow-mcp"
-version = "1.18.2"
+version = "1.18.3"
 description = "A Model Context Protocol (MCP) server implementation for ServiceNow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/servicenow_mcp/tools/sn_api.py
+++ b/src/servicenow_mcp/tools/sn_api.py
@@ -1303,6 +1303,24 @@ def sn_schema(
                 "No fields are defined directly on this table — it likely extends a base "
                 "table and inherits its fields. Query the parent table or use display_value."
             )
+        # Surface the MCP write path: if this table's code body is editable via
+        # manage_portal_component (BY SYS_ID), say so — closes the read/write
+        # discoverability gap (anything download_*_sources can pull, you can push
+        # back). Lazy import avoids a module-load cycle with portal_tools.
+        from servicenow_mcp.tools.portal_tools import PORTAL_COMPONENT_EDITABLE_FIELDS
+
+        editable = PORTAL_COMPONENT_EDITABLE_FIELDS.get(params.table)
+        if editable:
+            result["editable_via"] = {
+                "tool": "manage_portal_component",
+                "action": "update",
+                "fields": sorted(editable),
+                "by": "sys_id",
+                "note": (
+                    "Edit these fields by sys_id via manage_portal_component(action='update'). "
+                    "Names aren't globally unique — target by sys_id, not name."
+                ),
+            }
         _cache_put(ck, result, ttl=_METADATA_CACHE_TTL_SECONDS)
         return result
     except Exception as exc:

--- a/src/servicenow_mcp/tools/widget_dependency_tools.py
+++ b/src/servicenow_mcp/tools/widget_dependency_tools.py
@@ -323,7 +323,13 @@ def _list_dependencies(
         return {
             "success": False,
             "error": f"Failed to fetch widgets: {exc}",
-            "hint": "Check the widget filter and that the active instance is reachable.",
+            "hint": (
+                "Check the widget filter and that the active instance is reachable. "
+                "If the instance is unreachable, answer OFFLINE from a prior download "
+                "(0 API) with query_local_graph(question='used_by'|'uses'|'impact', "
+                "name=<widget>)."
+            ),
+            "offline_alternative": "query_local_graph",
         }
 
     widget_ids = [_ref_value(w.get("sys_id")) for w in widgets if w.get("sys_id")]

--- a/tests/test_sn_api_extended.py
+++ b/tests/test_sn_api_extended.py
@@ -537,6 +537,42 @@ class TestSnSchema:
         result = sn_schema(config, auth, params)
         assert result["success"] is False
 
+    def test_editable_table_surfaces_write_path(self):
+        # P2 discoverability: a code-bearing table editable via
+        # manage_portal_component must advertise that write path in its schema.
+        config = _make_config()
+        auth = MagicMock()
+        resp = _mock_response(
+            {
+                "result": [
+                    {
+                        "element": "script",
+                        "column_label": "Script",
+                        "internal_type": "script",
+                        "max_length": "8000",
+                        "mandatory": "false",
+                        "reference": "",
+                    }
+                ]
+            }
+        )
+        auth.make_request.return_value = resp
+        result = sn_schema(config, auth, SchemaParams(table="sys_script_include"))
+        assert result["success"] is True
+        assert result["editable_via"]["tool"] == "manage_portal_component"
+        assert result["editable_via"]["by"] == "sys_id"
+        assert "script" in result["editable_via"]["fields"]
+
+    def test_non_editable_table_has_no_write_path(self):
+        config = _make_config()
+        auth = MagicMock()
+        resp = _mock_response({"result": [{"element": "number", "column_label": "Number"}]})
+        auth.make_request.return_value = resp
+        # cmdb_ci is not in PORTAL_COMPONENT_EDITABLE_FIELDS — no write path claim.
+        result = sn_schema(config, auth, SchemaParams(table="cmdb_ci"))
+        assert result["success"] is True
+        assert "editable_via" not in result
+
 
 # ---------------------------------------------------------------------------
 # sn_discover

--- a/tests/test_widget_dependency.py
+++ b/tests/test_widget_dependency.py
@@ -218,6 +218,17 @@ class TestReadRouting:
         assert out["dependency_map"][0]["dependencies"][0]["name"] == "Common CSS"
         chain.assert_not_called()  # source chain must NOT be hit
 
+    def test_dependency_fetch_failure_points_to_offline_graph(self):
+        # P2 no-dead-end: when the live widget fetch fails (instance unreachable),
+        # the error must hand back the OFFLINE alternative, not a flat dead-end.
+        with patch(f"{DEV}._sn_get", side_effect=Exception("connection refused")):
+            out = manage_widget_dependency(
+                _config(), MagicMock(), _p(action="get", target="dependency", widget_id="W1")
+            )
+        assert out["success"] is False
+        assert out["offline_alternative"] == "query_local_graph"
+        assert "query_local_graph" in out["hint"]
+
     def test_include_source_is_only_source_trigger(self):
         sentinel = {"success": True, "_via": "chain"}
         with patch(f"{PORTAL}.resolve_widget_chain", return_value=sentinel) as chain:


### PR DESCRIPTION
## Summary

Friction-reduction roadmap **P2 remainder** (issue #57). Both changes are additive and follow the same *"no dead-end / point to the existing read-only tool"* pattern as #59.

The `portal_` naming is **intentionally left as-is** — renaming a public tool name (`manage_portal_component`) is high-churn / low-reward and the misnomer is cosmetic (discussed and agreed).

## Changes

### sn_schema advertises the MCP write path
`sn_schema` now adds `editable_via` when a table's code body is writable through `manage_portal_component` (by `sys_id`), reusing the single-source `PORTAL_COMPONENT_EDITABLE_FIELDS` (lazy import — no cycle). Closes the read/write discoverability gap: a table you can `download_*_sources` you can push back.

```json
"editable_via": {
  "tool": "manage_portal_component", "action": "update",
  "fields": ["script"], "by": "sys_id",
  "note": "Edit these fields by sys_id ... target by sys_id, not name."
}
```

### widget-dependency live failure → offline alternative
`manage_widget_dependency`'s live widget-fetch failure now hands back the **offline** alternative (`query_local_graph`, 0 API) instead of a flat dead-end — for when the instance is unreachable. A true auto-fallback was rejected (it would duplicate `query_local_graph` and guess the download root — YAGNI).

## Test plan
- [x] `pytest tests/` — **3330 passed, 5 skipped** (+3 new tests)
- [x] isort + black + ruff clean (pre-commit passed)
- [x] No import cycle (`sn_api` ⇄ `portal_tools` lazy import verified)
- [x] New tests: editable table advertises write path; non-editable does not; widget-dep fetch failure points to `query_local_graph`.

## Notes
- Patch bump 1.18.2 → 1.18.3. Tag `v1.18.3` after merge.
- This completes the issue #57 friction roadmap (P0-1, P0-3 in v1.18.0; hardened v1.18.1; P0-2 + P1-1 + P2(SI) in v1.18.2; P2(schema + widget) here). Deliberately NOT done: ACL pre-flight block (P1-2 — Protected≠uncallable, keep reactive), portal_ rename.